### PR TITLE
Blank screen on empty directory

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -3,7 +3,7 @@ function hovered()
 	if hovered then
 		return hovered
 	else
-		return ""
+		return nil  -- Return nil instead of empty string
 	end
 end
 
@@ -17,6 +17,10 @@ local function setup(_, options)
 	if Yatline ~= nil then
 		function Yatline.coloreds.get:created_time()
 			local h = hovered()
+			if not h then  -- Check if h is nil
+				return {}  -- Return empty table when no item is hovered
+			end
+			
 			local created_time = {}
 			local time = " C: " .. os.date("%Y-%m-%d %H:%M", h.cha.btime // 1) .. " "
 


### PR DESCRIPTION
**Problem:** When a directory is empty, the plugin causes yazi to show a blank terminal screen instead of the normal "No items" yazi message.

**Root Cause:** The `hovered()` function returns an empty string `""` when there's no hovered item, but then `created_time()` tries to access `.cha.btime` on that string, causing a crash. (probably, that's what Claude told me)

**Fix:** 
Change in `hovered()` function:
```lua
return nil  -- instead of return ""
```
Add nil check in created_time() function:

```lua
if not h then
    return {}
end
```